### PR TITLE
Added masking on shapefile using salem

### DIFF
--- a/GEFF_ERAI_Python3.ipynb
+++ b/GEFF_ERAI_Python3.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,6 +466,389 @@
     "# Plot the map of 95th percentile as threshold of VERY HIGH danger\n",
     "daily_danger_threshold_maps[4].plot();"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import salem\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shapefile = \"/Users/mirkodandrea/.salem_cache/salem-sample-data-b6d201fd8c228d5a1a6ea97964ef769dfef186ec/shapes/world_borders/world_borders.shp\"\n",
+    "ds_name = \"ECMWF_FWI_20180710_1200_hr_fwi.nc\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<xarray.Dataset>\n",
+       "Dimensions:  (lat: 2560, lon: 5120, time: 10)\n",
+       "Coordinates:\n",
+       "  * lon      (lon) float32 -180.0 -179.92969 -179.85938 ... 179.85938 179.92969\n",
+       "  * lat      (lat) float32 89.94619 89.87648 89.80636 ... -89.87648 -89.94619\n",
+       "  * time     (time) datetime64[ns] 2018-07-10 2018-07-11 ... 2018-07-19\n",
+       "Data variables:\n",
+       "    fwi      (time, lat, lon) float32 ...\n",
+       "Attributes:\n",
+       "    CDI:               Climate Data Interface version 1.8.2 (http://mpimet.mp...\n",
+       "    history:           Thu Sep 06 16:22:20 2018: cdo --silent sellonlatbox,-1...\n",
+       "    Conventions:       CF-1.6\n",
+       "    Reference date:    20180710\n",
+       "    ECMWF fire model:  2.2\n",
+       "    Lincense:          Copernicus\n",
+       "    version:           2.2\n",
+       "    NCO:               4.6.7\n",
+       "    CDO:               Climate Data Operators version 1.8.2 (http://mpimet.mp..."
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds = xr.open_dataset(ds_name)\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>CAT</th>\n",
+       "      <th>FIPS_CNTRY</th>\n",
+       "      <th>CNTRY_NAME</th>\n",
+       "      <th>AREA</th>\n",
+       "      <th>POP_CNTRY</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>min_x</th>\n",
+       "      <th>max_x</th>\n",
+       "      <th>min_y</th>\n",
+       "      <th>max_y</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>AA</td>\n",
+       "      <td>Aruba</td>\n",
+       "      <td>193.0</td>\n",
+       "      <td>71218.0</td>\n",
+       "      <td>POLYGON ((-69.882233 12.41111, -69.946945 12.4...</td>\n",
+       "      <td>-70.063339</td>\n",
+       "      <td>-69.873337</td>\n",
+       "      <td>12.411110</td>\n",
+       "      <td>12.631109</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>AC</td>\n",
+       "      <td>Antigua and Barbuda</td>\n",
+       "      <td>443.0</td>\n",
+       "      <td>68320.0</td>\n",
+       "      <td>POLYGON ((-61.738892 17.540554, -61.751945 17....</td>\n",
+       "      <td>-61.875282</td>\n",
+       "      <td>-61.729172</td>\n",
+       "      <td>17.540554</td>\n",
+       "      <td>17.724998</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>AC</td>\n",
+       "      <td>Antigua and Barbuda</td>\n",
+       "      <td>443.0</td>\n",
+       "      <td>68320.0</td>\n",
+       "      <td>POLYGON ((-61.73806 16.989719, -61.82917 16.99...</td>\n",
+       "      <td>-61.891113</td>\n",
+       "      <td>-61.666389</td>\n",
+       "      <td>16.989719</td>\n",
+       "      <td>17.167221</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4</td>\n",
+       "      <td>AG</td>\n",
+       "      <td>Algeria</td>\n",
+       "      <td>2381740.0</td>\n",
+       "      <td>32129324.0</td>\n",
+       "      <td>POLYGON ((2.96361 36.802216, 2.981389 36.80693...</td>\n",
+       "      <td>-8.667223</td>\n",
+       "      <td>11.986475</td>\n",
+       "      <td>18.976387</td>\n",
+       "      <td>37.091385</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5</td>\n",
+       "      <td>AJ</td>\n",
+       "      <td>Azerbaijan</td>\n",
+       "      <td>86600.0</td>\n",
+       "      <td>7868385.0</td>\n",
+       "      <td>POLYGON ((48.583954 41.83577, 48.613045 41.824...</td>\n",
+       "      <td>45.022942</td>\n",
+       "      <td>50.374992</td>\n",
+       "      <td>38.389153</td>\n",
+       "      <td>41.897057</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   CAT FIPS_CNTRY           CNTRY_NAME       AREA   POP_CNTRY  \\\n",
+       "0    1         AA                Aruba      193.0     71218.0   \n",
+       "1    2         AC  Antigua and Barbuda      443.0     68320.0   \n",
+       "2    2         AC  Antigua and Barbuda      443.0     68320.0   \n",
+       "3    4         AG              Algeria  2381740.0  32129324.0   \n",
+       "4    5         AJ           Azerbaijan    86600.0   7868385.0   \n",
+       "\n",
+       "                                            geometry      min_x      max_x  \\\n",
+       "0  POLYGON ((-69.882233 12.41111, -69.946945 12.4... -70.063339 -69.873337   \n",
+       "1  POLYGON ((-61.738892 17.540554, -61.751945 17.... -61.875282 -61.729172   \n",
+       "2  POLYGON ((-61.73806 16.989719, -61.82917 16.99... -61.891113 -61.666389   \n",
+       "3  POLYGON ((2.96361 36.802216, 2.981389 36.80693...  -8.667223  11.986475   \n",
+       "4  POLYGON ((48.583954 41.83577, 48.613045 41.824...  45.022942  50.374992   \n",
+       "\n",
+       "       min_y      max_y  \n",
+       "0  12.411110  12.631109  \n",
+       "1  17.540554  17.724998  \n",
+       "2  16.989719  17.167221  \n",
+       "3  18.976387  37.091385  \n",
+       "4  38.389153  41.897057  "
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load the shapefile\n",
+    "shp_df = salem.read_shapefile(shapefile)\n",
+    "shp_df.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>CAT</th>\n",
+       "      <th>FIPS_CNTRY</th>\n",
+       "      <th>CNTRY_NAME</th>\n",
+       "      <th>AREA</th>\n",
+       "      <th>POP_CNTRY</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>min_x</th>\n",
+       "      <th>max_x</th>\n",
+       "      <th>min_y</th>\n",
+       "      <th>max_y</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3444</th>\n",
+       "      <td>234</td>\n",
+       "      <td>US</td>\n",
+       "      <td>United States</td>\n",
+       "      <td>9629091.0</td>\n",
+       "      <td>293027571.0</td>\n",
+       "      <td>POLYGON ((-88.10777299999999 30.273609, -88.10...</td>\n",
+       "      <td>-88.312500</td>\n",
+       "      <td>-88.070282</td>\n",
+       "      <td>30.228607</td>\n",
+       "      <td>30.273609</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3445</th>\n",
+       "      <td>234</td>\n",
+       "      <td>US</td>\n",
+       "      <td>United States</td>\n",
+       "      <td>9629091.0</td>\n",
+       "      <td>293027571.0</td>\n",
+       "      <td>POLYGON ((-164.77002 66.530823, -164.775299 66...</td>\n",
+       "      <td>-165.470825</td>\n",
+       "      <td>-164.762238</td>\n",
+       "      <td>66.411652</td>\n",
+       "      <td>66.540817</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3446</th>\n",
+       "      <td>234</td>\n",
+       "      <td>US</td>\n",
+       "      <td>United States</td>\n",
+       "      <td>9629091.0</td>\n",
+       "      <td>293027571.0</td>\n",
+       "      <td>POLYGON ((-166.210541 66.208878, -166.287781 6...</td>\n",
+       "      <td>-166.671387</td>\n",
+       "      <td>-166.169464</td>\n",
+       "      <td>66.102768</td>\n",
+       "      <td>66.223038</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3447</th>\n",
+       "      <td>234</td>\n",
+       "      <td>US</td>\n",
+       "      <td>United States</td>\n",
+       "      <td>9629091.0</td>\n",
+       "      <td>293027571.0</td>\n",
+       "      <td>POLYGON ((-162.349426 63.5886, -162.377472 63....</td>\n",
+       "      <td>-162.703613</td>\n",
+       "      <td>-162.337494</td>\n",
+       "      <td>63.538605</td>\n",
+       "      <td>63.637497</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3448</th>\n",
+       "      <td>234</td>\n",
+       "      <td>US</td>\n",
+       "      <td>United States</td>\n",
+       "      <td>9629091.0</td>\n",
+       "      <td>293027571.0</td>\n",
+       "      <td>POLYGON ((-148.029724 60.927773, -148.022797 6...</td>\n",
+       "      <td>-148.134460</td>\n",
+       "      <td>-147.909729</td>\n",
+       "      <td>60.789719</td>\n",
+       "      <td>60.928604</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      CAT FIPS_CNTRY     CNTRY_NAME       AREA    POP_CNTRY  \\\n",
+       "3444  234         US  United States  9629091.0  293027571.0   \n",
+       "3445  234         US  United States  9629091.0  293027571.0   \n",
+       "3446  234         US  United States  9629091.0  293027571.0   \n",
+       "3447  234         US  United States  9629091.0  293027571.0   \n",
+       "3448  234         US  United States  9629091.0  293027571.0   \n",
+       "\n",
+       "                                               geometry       min_x  \\\n",
+       "3444  POLYGON ((-88.10777299999999 30.273609, -88.10...  -88.312500   \n",
+       "3445  POLYGON ((-164.77002 66.530823, -164.775299 66... -165.470825   \n",
+       "3446  POLYGON ((-166.210541 66.208878, -166.287781 6... -166.671387   \n",
+       "3447  POLYGON ((-162.349426 63.5886, -162.377472 63.... -162.703613   \n",
+       "3448  POLYGON ((-148.029724 60.927773, -148.022797 6... -148.134460   \n",
+       "\n",
+       "           max_x      min_y      max_y  \n",
+       "3444  -88.070282  30.228607  30.273609  \n",
+       "3445 -164.762238  66.411652  66.540817  \n",
+       "3446 -166.169464  66.102768  66.223038  \n",
+       "3447 -162.337494  63.538605  63.637497  \n",
+       "3448 -147.909729  60.789719  60.928604  "
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Query for the US\n",
+    "shp_df_us = shdf.query('CNTRY_NAME==\"United States\"')\n",
+    "shp_df_us.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/mirkodandrea/anaconda3/envs/feno_analysis/lib/python3.6/site-packages/xarray/core/nanops.py:161: RuntimeWarning: Mean of empty slice\n",
+      "  return np.nanmean(a, axis=axis, dtype=dtype)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x1c25301550>"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAADKCAYAAACohkc8AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAGzZJREFUeJzt3X2QHHd95/H3t7tnZp+1K2kl9ASWgxywgThmzziYu3ISLMm+q5ikYs4+HnRAlVJ3UBUIhBi4HARCHUklmFAF5JzDhakjNoaEQkcZy8LBB3ccoBX4SRay1s+yhCTrYbW7MzsP3d/7o3vFSJal3dVqZrX9eVVtTc93fjPT/aud+Uz3r+c35u6IiEh+Be1eARERaS8FgYhIzikIRERyTkEgIpJzCgIRkZxTEIiI5FzLg8DMNprZbjMbMbNbWv38IiJyMmvl9wjMLAQeB64F9gLbgZvd/bGWrYSIiJyk1XsEVwIj7v6ku9eAu4AbWrwOIiLSJGrx860Cnmu6vhd4Q3MDM9sMbAbo7u5+/ate9arWrZ2IyAKwY8eOF9x9cLrtWx0EdpraScem3P024DaAoaEhHx4ebsV6iYgsGGb2zEzat/rQ0F5gTdP11cC+Fq+DiIg0aXUQbAfWmdlaMysCNwFbWrwOIiLSpKWHhty9YWbvA7YCIXC7u+9s5TqIiMjJWj1GgLvfA9zT6ucVEZHT0zeLRURyTkEgIpJzCgIRkZxTEIiI5JyCQEQk5xQEIiI5pyAQEck5BYGISM4pCEREck5BICKScwoCEZGcUxCIiORcyyeda4cNi96dLiTJr4pBgJlBkP1WTuK4O1tHb2/9CoqItNGCDYL1nW+HxE+80Ztlb/hhCO4Qx+lPo2Xh4HGCxzHXhm9Nbz+VGdviu1uz8iIiLbTggmB96W1YRwkrFrEoIimX00/7UwfBqlU8jsEC8GwP4dQ3frP0dsDCkKCzA0ql1m2EiEgLLbgguK/6tRPL14ZvxcIQiyI8nvrkH6dv/M2/nhyEJ0IhXNQHK5bR6O+i0VsgGq8THC3jzzzfys0QEWmZBTdYvL54c3p4B9JDOWFIUqunNwZG2NtL0NuLFSKCUrrnEHSUCJcsJlq+DKII9h8kmGwQjdcJx6vYZI1gUV8bt0pE5PxZUHsE64s3nzjss6HrHbh7ukdghscJQamU3h7HhINL8XqdIIrw7k6s3sA7S9iRUbzRgEd2Y4mTJDGJ2dmfXETkArWgguC+2p2nra/vfDtBZ8eJYPAgwCfKJwaM/egxklotHVNoNNIgyIRLFpOMT6QDzyIiC9CCCoIpGxa9GwsDfLIKQZDuCbhDkpBUq1ixmA4IFyLiw0dO3G8qAIKOjl/VanW8ViPo6mr5doiItMKCC4INi96dHgqarEIYYoUo/TQfxxCGBF1duDtJuXzyJ/++PpLKJF6vkUxOpkUzqFbBnWRiok1bJCJyfi24weKto7enb/DBrzYtqUySVCpQr+NxjNdqYAEWpTm4LfkG1t2F12snrm9LvpGeXXS67xSIiCwgC26PAGDr+B0nlq8N35q+6YchhCHeaOD1BkFHiWSyyrbkG1wb3QRJnL75Nzn1+onHDG48cVvzsojIhch8Hn/iHRoa8uHh4Tl5rGvDt7Itvjv9xnEc443GOb+BXxvceGJZYSAi84WZ7XD3oem2P6dDQ2b2tJk9YmYPmtlwVltsZtvMbE92OZDVzcw+b2YjZvawmV1xLs89U1PTQ3itxn21O9M9geDGk97MZ/yYU4eQ4JweR0SkneZijOC33f3ypvS5Bbjf3dcB92fXAa4D1mV/m4EvzcFzT9vUG3XzfEHNb+TnYlvyDTBTGIjIBel8jBHcAFyTLd8BPAD8WVb/qqfHon5sZv1mtsLd95+HdQCyN//sy2Dn+9DNVMCsL73tpGkuRETmu3MNAgfuMzMH/ru73wYsn3pzd/f9ZrYsa7sKeK7pvnuz2klBYGabSfcYePnLX35OK9eO4/YKARG50JxrEFzt7vuyN/ttZvaLM7Q93TwNLxqpzsLkNkgHi89x/URE5CzOaYzA3fdllweBbwFXAgfMbAVAdnkwa74XWNN099XAvpk+p47Di4jMrVkHgZl1m1nv1DKwHngU2AJsypptAr6dLW8B3pmdPXQVMDqb8QGdpikiMrfO5dDQcuBb2S9/RcA/uvu9ZrYduNvM3gM8C0x9hL8HuB4YAcrAu87huUVEZI7MOgjc/UngN05TPwz87mnqDrx3ts8nIiLnx4KcYmK+2viaj2HHJ8CMx9+7hsZAA4oJ0cEi0YQRTULPcwn1LmNy0LAGxJ2QRBBOQmV1zKKdIWHVKY05YTWh1hvQv3OMuKdI4YVxaMTpKbOHjkAYgAXce+CLmgpDRF6SgqCFGv2djL92MdFkQmNJA0LnotUv8Pz+lXgI0QSMXhxQGIeOw87ixyqUV6S/lTy+MiQ5GNLzy5jJRQFBw6l3BRTHE+K+IsVnDkO9gXd3wtHjWEcJggAvV7juFR8gXLqEDZf/OSTAk8+SvO6VBDufYuvo7bPalje/6S/53v/5L3PYOyLSLgtu9tH5rLq4xMSKgH3/vsZvXTrCr1+0nwP/exUYFCagstwplGHR0w16n63jgYFDeTDAYljyaAzAwC/KdO0ts+jxMToOVgnHa8RL+6BUxCYqWKmIVyrp9a7OdAbVZUuIe0qU1/axdfwObPgx6q9fx8b+98x4OzZc/ucnvqgnIhc+7RG00OjaiCSCeLzAjgdehRsk/QnFi8apPN1D0DDGX54AEaWjzsSKIsVRqC6BVQ9UODjUSf9Ig7Bco7Yk/aGcuBTgYYniWB2sl3D/EXx8HApFKFfwRgPr7MSOTxA1YjxMsz/+rdeSFANqr3/lGdf52qs+mf5kZyEkGq1AI2b8sqX0PnLwxER+InJhUxC0UGW5E3c6Vkyor6rR1TdJqVAnDJxb/+CrfGzkD+iI6lz8psPc+9il9Dzcwcp79vLU21ez/42dFMbh2Csjglo3STGg3h0QVRIK4zGF/cex4+N4vQ5RBEmc/r5CGKZ7BMUCVqun4whAUG1gjYTJZSXe/K8/zfd++LEXre+1b/wU9b4iSSGgdLTK2KsGiAvGj+/8YKu7TkTOIwVBC9UGGxRfiIgTgwQqE0V6llRZVJrkE0/dwMu6j3Os2snW3a8mPFCi4wVn14dWEB13SkeMpADLtpc5dEUX/U/U6XmmQjDZIChXsYlK+nOcQQiBpb/IFkVYoUA82E9QrUOc4KUCAB4GhOUaPSOTeCE8aT03XvZR6ku6scAojtYIJqrUF3fReaBK4dkX2tF1InIeKQhaKTFqK+qEpTj98bPYODLazdGgiyQOeC7qp3q8xMCOAtUB48hrE6KxgKABHsLArjqTy0p0HE5IIiPujAgrdaxaSz/xm+GLeiBJoN4gXtxDOFHDCwGNzk6CWow1Et5449/Q7U7cUyI6ViE4Ns7GSz6c/rRneRJLEgpxAmYkXSUaizqJxmv4ridINDYgsuAoCFrI6kY0UCOKEiqjHYQdMZ2dNSYmOoiPF+h4IqL2mirH3zTJwP0dRBMB5ZWOJcaKH1U4tq6DvqdrTCwrEtYDPDQKR42kv4ekGBKU6zT6O2j0FKj3pAPMhbEije6QoOF0HKhQXdpJVEmo9xUJK+ngs3d3khQjgsn0pzopFfFiuucQ1NLfdd76s79oS5+JyPmnIGihVQ/AoZucZGcffb9xlKU9Ezw58jJ6nojoeyYhrDYYvyQgmYiYXGoUR51FI3D8YqfRHTH4v0Z4/j+sA2B0rdHxguNBD3HBqHcZ1cXpfQplp/NQg6Dh4BBWnXAyprqkg7gjoDAekxQCPDImV/US1BIKxyaxaj39PeeOIvWlXRT3jWLVGvc99dn2dpyInFc6fbSF/u83P0TPfT00ehLqjRD79FIW/zwkqKdfGiuMxbz6w4/zsh8aq/5uB8t/kB6PX/qQU9w6jHV30v9kg7DqVJc49R7j2CtDJlYGTC41ogmoDBpx0ZhcElFZWmBiRYGwGhNN1CmM1el+Zpzi4Qode8eIjlUJyw3CyUZ6OAnwFUupXLwYDO79xWfw8Yl2dpmItEBufrN4PnnNn95K5fVl4kZA/49KRBUorzCiMoyvcZY8Aov2lIm7Ig5fln6hbNGTDTrv/Vl6FtDrLuGZ63qZfEUNmwgpHgsIqkbxOEQVJ6hD0HBqvUahDJ2HGkSVmMKRMsHxMt7VgQcBFsdMruqj9EIlPbPInerLeigdLGO1BnZ8gu8++7k295aIzNRMf7NYh4baYPV3DrLn9T10904yuaQDD6HR4+DGJX89gkUhyehxGm98NYt/USOsxsSFAE+caHCAQ5f14JFjkyHemVALIRoLsCSdpiKqOkHd6d1bJYkCan0RHQfLWCP91G/lScwdwpDSoTIeBCTdRSYHi/Q8djjdOxibwCuTbe4pEWkFHRpqg3t3/Te6/18XSWJc/XsP0ehxPHQa3U689mUk4xMEiwfoePoIxcMVirv3EU00iNaspPy61TQ608cJxwLCYxFWN+KiEzQgrELpaIOeZyaIjlaoLC1QmIgJyjVsdByPQrzQlP8jzwJQWV4irKRBQRBAo8G9x77c4p4RkXbQHkGbPPx3HwDgupe/n/gva4S/LFLvcQ68oZelXeso7d6HJQ4P7aYRx4THx/A1K+l66DlGL76YwpjhfY6TnoZaOmYMPN4gnEwoHZ4k7iwQutP3+BgWx1ilitfqWPYm77UaxDG2cjn1RSWiiZh6b0hyyRJ+uOVP29s5ItJS2iNos+8++zlWfiei47BRPBZQ74FDl3dAFJH0dRGuXklQKsG6V2DVGt5oEJeMzkOOF8AaUDpqhJMQFy093h87xecOEx6dIDw2TnC8DJNV8ATqdQCspxtb1Id3dxBN1AmrCYu271MIiOSQ9gjmgR/d/aGTrv/6J25lct1yitsfh8ElWG8vVGrEA72wtI+efQnjKwI6fwk4FMpOadQpHU3P+Q+PjeOjY+k01O5YsYg30tswwxsx9HThpSJxZwFzJxqr8l2dJiqSSwqCeWj3Jz7wkrdds/Gv6DxYI4mKjK8O6H4+SU8X7Tf6dpfxYoSPl9PJ5jzA6410euo4Ts8M6gIrFPADLxB0dRKMFsAdr9ZauIUiMp8oCC4wD9z7Z1x2y614ALVFTv8eZ+CRYwRjFZJF3YQvHCcpp0GwtfI/Wd/5drxaxRNnW+Ou0z7mxiWb0/mJRCSX9D2CBeBf/cfPgsPArjGCZw5w74Evzvgx1pfexn3Vr52HtRORVpvp9wg0WLwAbP/Kn1DtN6zWmHUIEFh6KSK5oyBYIOo90OjrmNV976t+Da/V8EZ9jtdKRC4EGiNYIHZ9+qUHmKdjW3w364s3z9HaiMiFRHsEcsJ9tTvbvQoi0gYKAhGRnDtrEJjZ7WZ20MwebaotNrNtZrYnuxzI6mZmnzezETN72MyuaLrPpqz9HjPbdH42R0REZmo6ewRfATaeUrsFuN/d1wH3Z9cBrgPWZX+bgS9BGhzAx4E3AFcCH58KDxERaa+zBoG7/wA4ckr5BuCObPkO4C1N9a966sdAv5mtADYA29z9iLsfBbbx4nAREZE2mO0YwXJ33w+QXS7L6quA55ra7c1qL1V/ETPbbGbDZjZ86NChWa6eiIhM11wPFp9ungI/Q/3FRffb3H3I3YcGBwfndOVEROTFZhsEB7JDPmSXB7P6XmBNU7vVwL4z1EVEpM1mGwRbgKkzfzYB326qvzM7e+gqYDQ7dLQVWG9mA9kg8fqsJiIibXbWbxab2Z3ANcBSM9tLevbPZ4C7zew9wLPAjVnze4DrgRGgDLwLwN2PmNmngO1Zu0+6+6kD0CIi0gaafVREZIHR7KMiIjIjCgIRkZxTEIiI5JyCQEQk5xQEIiI5pyAQEck5BYGISM4pCEREck5BICKScwoCEZGcUxCIiOScgkBEJOcUBCIiOacgEBHJOQWBiEjOKQhERHJOQSAiknMKAhGRnFMQiIjknIJARCTnFAQiIjmnIBARyTkFgYhIzp01CMzsdjM7aGaPNtU+YWbPm9mD2d/1Tbd9xMxGzGy3mW1oqm/MaiNmdsvcb4qIiMzGdPYIvgJsPE39Vne/PPu7B8DMLgVuAi7L7vNFMwvNLAS+AFwHXArcnLUVEZE2i87WwN1/YGYXTfPxbgDucvcq8JSZjQBXZreNuPuTAGZ2V9b2sRmvsYiIzKlzGSN4n5k9nB06Gshqq4DnmtrszWovVRcRkTabbRB8Cfg14HJgP/C3Wd1O09bPUH8RM9tsZsNmNnzo0KFZrp6IiEzXrILA3Q+4e+zuCfAP/Orwz15gTVPT1cC+M9RP99i3ufuQuw8NDg7OZvVERGQGZhUEZrai6ervA1NnFG0BbjKzkpmtBdYBPwW2A+vMbK2ZFUkHlLfMfrVFRGSunHWw2MzuBK4BlprZXuDjwDVmdjnp4Z2ngT8CcPedZnY36SBwA3ivu8fZ47wP2AqEwO3uvnPOt0ZERGbM3E97qH5eGBoa8uHh4XavhojIBcXMdrj70HTb65vFIiI5pyAQEck5BYGISM4pCEREck5BICKScwoCEZGcUxCIiOScgkBEJOcUBCIiOacgEBHJOQWBiEjOKQhERHJOQSAiknMKAhGRnFMQiIjknIJARCTnFAQiIjmnIBARyTkFgYhIzikIRERyTkEgIpJzCgIRkZxTEIiI5JyCQEQk584aBGa2xsy+b2a7zGynmf1xVl9sZtvMbE92OZDVzcw+b2YjZvawmV3R9FibsvZ7zGzT+dssERGZrunsETSAD7r7q4GrgPea2aXALcD97r4OuD+7DnAdsC772wx8CdLgAD4OvAG4Evj4VHiIiEj7nDUI3H2/u/8sWx4DdgGrgBuAO7JmdwBvyZZvAL7qqR8D/Wa2AtgAbHP3I+5+FNgGbJzTrRERkRmb0RiBmV0E/CbwE2C5u++HNCyAZVmzVcBzTXfbm9Veqn7qc2w2s2EzGz506NBMVk9ERGZh2kFgZj3APwHvd/fjZ2p6mpqfoX5ywf02dx9y96HBwcHprp6IiMzStILAzAqkIfA1d//nrHwgO+RDdnkwq+8F1jTdfTWw7wx1ERFpo+mcNWTAl4Fd7v7Zppu2AFNn/mwCvt1Uf2d29tBVwGh26GgrsN7MBrJB4vVZTURE2iiaRpurgXcAj5jZg1nto8BngLvN7D3As8CN2W33ANcDI0AZeBeAux8xs08B27N2n3T3I3OyFSIiMmvm/qLD9PPG0NCQDw8Pt3s1REQuKGa2w92Hptte3ywWEck5BYGISM4pCEREck5BICKScwoCEZGcUxCIiOScgkBEJOcUBCIiOacgEBHJOQWBiEjOKQhERHJOQSAiknMKAhGRnFMQiIjknIJARCTnFAQiIjmnIBARyTkFgYhIzikIRERyTkEgIpJzCgIRkZxTEIiI5JyCQEQk5xQEIiI5d9YgMLM1ZvZ9M9tlZjvN7I+z+ifM7HkzezD7u77pPh8xsxEz221mG5rqG7PaiJndcn42SUREZiKaRpsG8EF3/5mZ9QI7zGxbdtut7v43zY3N7FLgJuAyYCXwPTO7JLv5C8C1wF5gu5ltcffH5mJDRERkds4aBO6+H9ifLY+Z2S5g1RnucgNwl7tXgafMbAS4MrttxN2fBDCzu7K2CgIRkTaa0RiBmV0E/Cbwk6z0PjN72MxuN7OBrLYKeK7pbnuz2kvVT32OzWY2bGbDhw4dmsnqiYjILEw7CMysB/gn4P3ufhz4EvBrwOWkewx/O9X0NHf3M9RPLrjf5u5D7j40ODg43dUTEZFZms4YAWZWIA2Br7n7PwO4+4Gm2/8B+E52dS+wpunuq4F92fJL1UVEpE2mc9aQAV8Gdrn7Z5vqK5qa/T7waLa8BbjJzEpmthZYB/wU2A6sM7O1ZlYkHVDeMjebISIiszWdPYKrgXcAj5jZg1nto8DNZnY56eGdp4E/AnD3nWZ2N+kgcAN4r7vHAGb2PmArEAK3u/vOMz3xjh07xs1s94y3auFZCrzQ7pVoM/VBSv2gPoCz98ErZvJg5v6iw/TzhpkNu/tQu9ej3dQP6oMp6gf1Acx9H+ibxSIiOacgEBHJufkeBLe1ewXmCfWD+mCK+kF9AHPcB/N6jEBERM6/+b5HICIi55mCQEQk5+ZtECzkKauzuZkOmtmjTbXFZrbNzPZklwNZ3czs81k/PGxmVzTdZ1PWfo+ZbWrHtszWGaY3z1s/dJjZT83soawf/iKrrzWzn2Tb9PXsS5hkX9T8etYPP8nm/5p6rNNO/36hMLPQzH5uZt/JruexD542s0csndp/OKud/9eEu8+7P9IvnD0BXAwUgYeAS9u9XnO4ff8GuAJ4tKn218At2fItwF9ly9cD3yWdq+kq4CdZfTHwZHY5kC0PtHvbZtAHK4ArsuVe4HHg0hz2gwE92XKBdELHq4C7gZuy+t8D/ylb/s/A32fLNwFfz5YvzV4nJWBt9voJ2719M+yLPwH+EfhOdj2PffA0sPSU2nl/TczXPYIryaasdvcaMDVl9YLg7j8AjpxSvgG4I1u+A3hLU/2rnvox0J9N77EB2ObuR9z9KLAN2Hj+135uuPt+d/9ZtjwGTE1vnrd+cHcfz64Wsj8Hfgf4ZlY/tR+m+uebwO9m08CcmP7d3Z8Cmqd/n/fMbDXwb4H/kV03ctYHZ3DeXxPzNQimNWX1ArPc099+ILtcltXPaVrvC4GdPL157vohOyTyIHCQ9EX7BHDM3RtZk+ZtOrG92e2jwBIu/H74HPBhIMmuLyF/fQDph4D7zGyHmW3Oauf9NTGt2UfbYFpTVufEOU3rPd/ZKdObpx/sTt/0NLUF0Q+ezsV1uZn1A98CXn26ZtnlgusHM/t3wEF332Fm10yVT9N0wfZBk6vdfZ+ZLQO2mdkvztB2zvphvu4RnGkq64XqQLZbNzWz68Gs/lJ9ccH3kZ1menNy2A9T3P0Y8ADp8d5+M5v6oNa8TSe2N7t9Eelhxgu5H64Gfs/MniY9DPw7pHsIeeoDANx9X3Z5kPRDwZW04DUxX4Mgj1NWbwGmRvc3Ad9uqr8zO0PgKmA02z3cCqw3s4HsLIL1We2CkB3TfdH05uSvHwazPQHMrBN4M+l4yfeBP8yandoPU/3zh8C/eDpC+FLTv8977v4Rd1/t7heRvtb/xd3fRo76AMDMui39XXjMrJv0f/lRWvGaaPco+RlGz68nPZPkCeBj7V6fOd62O0l/1a1Omt7vIT3GeT+wJ7tcnLU14AtZPzwCDDU9zrtJB8RGgHe1e7tm2AdvIt1dfRh4MPu7Pof98Drg51k/PAr816x+Memb2AjwDaCU1Tuy6yPZ7Rc3PdbHsv7ZDVzX7m2bZX9cw6/OGspVH2Tb+1D2t3Pqfa8VrwlNMSEiknPz9dCQiIi0iIJARCTnFAQiIjmnIBARyTkFgYhIzikIRERyTkEgIpJz/x+HJSZ0ZeS9lAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# mask the dataset on the selected geometries\n",
+    "ds_us = ds.salem.roi(shape=shp_df_us)\n",
+    "\n",
+    "# Plot the mean value over time \n",
+    "plt.imshow(ds_us.fwi.mean('time'))"
+   ]
   }
  ],
  "metadata": {
@@ -484,7 +867,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.6.8"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
I've implemented an example of dataset masking on a shapefile using the [salem library](https://salem.readthedocs.io/en/latest/xarray_acc.html)

The code is included at the end of the notebook

```python
import salem

ds = xr.open_dataset(ds_name)
# Load the shapefile
shp_df = salem.read_shapefile(shapefile)
# Query for the US
shp_df_us = shdf.query('CNTRY_NAME=="United States"')
# mask the dataset on the selected geometries
ds_us = ds.salem.roi(shape=shp_df_us)
```